### PR TITLE
Change anchor tags from action links to render links

### DIFF
--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/ProxyPortletController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/ProxyPortletController.java
@@ -6,9 +6,9 @@
  * Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License.  You may obtain a
  * copy of the License at the following location:
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -59,6 +59,7 @@ import org.springframework.beans.factory.annotation.Required;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.portlet.bind.annotation.ActionMapping;
 import org.springframework.web.portlet.bind.annotation.EventMapping;
@@ -67,30 +68,30 @@ import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 
 /**
  * ProxyPortletController is the main view controller for web proxy portlets.
- * 
+ *
  * @author Jen Bourey, jennifer.bourey@gmail.com
  */
 @Controller
 @RequestMapping("VIEW")
 public class ProxyPortletController {
 
-    protected static final String CONTENT_SERVICE_KEY = "contentService";
-    protected static final String FILTER_LIST_KEY = "filters";
     public static final String PREF_CHARACTER_ENCODING = "sourcePageCharacterEncoding";
     public static final String CHARACTER_ENCODING_DEFAULT = "UTF-8";
-
+    protected static final String CONTENT_SERVICE_KEY = "contentService";
+    protected static final String FILTER_LIST_KEY = "filters";
     protected final Logger log = LoggerFactory.getLogger(this.getClass());
     private ApplicationContext applicationContext;
+    private final List<Pattern> knownHtmlContentTypes = new ArrayList<Pattern>();
+    @Resource(name = "contentSearchProvider")
+    private ISearchService searchService;
 
     @Autowired(required = true)
     public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }
 
-    private List<Pattern> knownHtmlContentTypes = new ArrayList<Pattern>();
-
     @Required
-    @Resource(name="knownHtmlContentTypes")
+    @Resource(name = "knownHtmlContentTypes")
     public void setKnownHtmlContentTypes(List<String> contentTypes) {
         knownHtmlContentTypes.clear();
         for (String contentType : contentTypes) {
@@ -98,29 +99,49 @@ public class ProxyPortletController {
         }
     }
 
-    @Resource(name="contentSearchProvider")
-    private ISearchService searchService;
-
     @RenderMapping
     public void showContent(final RenderRequest request, final RenderResponse response) {
-
-        // locate the content service to use to retrieve our HTML content
-        final IContentService<IContentRequest,IContentResponse> contentService = selectContentService(request);
-
-        // retrieve the HTML content
-        final IContentResponse proxyResponse;
+        IContentResponse proxyResponse = null;
         try {
-            proxyResponse = invokeProxy(contentService, request);
-        } catch (Exception e) {
-            log.error("Failed to proxy content", e);
-            // TODO: error handling
-            return;
+            // retrieve the HTML content
+            proxyResponse = invokeProxy(request);
+            final List<IDocumentFilter> filters = prepareFilters(request);
+            final Document document = parseDocument(request, proxyResponse);
+
+            // apply each of the document filters in order
+            for (final IDocumentFilter filter : filters) {
+                filter.filter(document, proxyResponse, request, response);
+            }
+
+            // write out the final content
+            OutputStream out = null;
+            try {
+                out = response.getPortletOutputStream();
+                IOUtils.write(document.html(), out);
+                out.flush();
+            } catch (IOException e) {
+                log.error("Exception writing proxied content", e);
+            } finally {
+                IOUtils.closeQuietly(out);
+            }
+
+        } catch (IOException e) {
+            log.error("Error parsing HTML content", e);
+        } finally {
+            if (proxyResponse != null) {
+                proxyResponse.close();
+            }
         }
 
-        // locate all filters configured for this portlet
-        final List<IDocumentFilter> filters = prepareFilters(request);
+    }
 
+    @RenderMapping("proxy.url")
+    public void showProxyContent(final RenderRequest request, final RenderResponse response) {
+        IContentResponse proxyResponse = null;
         try {
+            // retrieve the HTML content
+            proxyResponse = invokeProxy(request);
+            final List<IDocumentFilter> filters = prepareFilters(request);
             final Document document = parseDocument(request, proxyResponse);
 
             // apply each of the document filters in order
@@ -151,50 +172,34 @@ public class ProxyPortletController {
     }
 
     @ActionMapping
-    public void proxyTarget(final @RequestParam("proxy.url") String url,  final ActionRequest request,
+    public void proxyTarget(final @RequestParam("proxy.url") String url, final ActionRequest request,
                             final ActionResponse response) throws IOException {
-
         IContentResponse proxyResponse = null;
-
         try {
-          // locate the content service to use to retrieve our HTML content
-          final IContentService<IContentRequest,IContentResponse> contentService = selectContentService(request);
+            proxyResponse = invokeProxy(request);
 
-          final IContentRequest proxyRequest;
-          try {
-              proxyRequest = contentService.getRequest(request);
-          } catch (RuntimeException e) {
-              log.error("URL {} was not in the proxy list", url);
-              // TODO: how should we handle these errors?
-              return;
-          }
+            // TODO: this probably can only be an HTTP content type
+            if (proxyResponse instanceof HttpContentResponseImpl) {
 
-          // retrieve the HTML content
-          proxyResponse = contentService.getContent(proxyRequest, request);
-
-          // TODO: this probably can only be an HTTP content type
-          if (proxyResponse instanceof HttpContentResponseImpl) {
-
-            // Determine the content type of the proxied response.  If this is
-            // not an HTML type, we need to construct a resource URL instead
-            final HttpContentResponseImpl httpContentResponse = (HttpContentResponseImpl) proxyResponse;
-            final String responseContentType = httpContentResponse.getHeaders().get("Content-Type");
-            for (Pattern contentType : knownHtmlContentTypes) {
-                if (responseContentType != null && contentType.matcher(responseContentType).matches()) {
-                    final Map<String, String[]> params = request.getParameterMap();
-                    response.setRenderParameters(params);
-                    return;
+                // Determine the content type of the proxied response.  If this is
+                // not an HTML type, we need to construct a resource URL instead
+                final HttpContentResponseImpl httpContentResponse = (HttpContentResponseImpl) proxyResponse;
+                final String responseContentType = httpContentResponse.getHeaders().get("Content-Type");
+                for (Pattern contentType : knownHtmlContentTypes) {
+                    if (responseContentType != null && contentType.matcher(responseContentType).matches()) {
+                        final Map<String, String[]> params = request.getParameterMap();
+                        response.setRenderParameters(params);
+                        return;
+                    }
                 }
+
             }
 
-          }
-
-          // if this is not an HTML content type, use the corresponding resource
-          // URL in the session
-          final PortletSession session = request.getPortletSession();
-          @SuppressWarnings("unchecked")
-          final ConcurrentMap<String,String> rewrittenUrls = (ConcurrentMap<String,String>) session.getAttribute(URLRewritingFilter.REWRITTEN_URLS_KEY);
-          response.sendRedirect(rewrittenUrls.get(url));
+            // if this is not an HTML content type, use the corresponding resource
+            // URL in the session
+            final PortletSession session = request.getPortletSession();
+            @SuppressWarnings("unchecked") final ConcurrentMap<String, String> rewrittenUrls = (ConcurrentMap<String, String>) session.getAttribute(URLRewritingFilter.REWRITTEN_URLS_KEY);
+            response.sendRedirect(rewrittenUrls.get(url));
         } finally {
             if (proxyResponse != null) {
                 proxyResponse.close();
@@ -204,25 +209,11 @@ public class ProxyPortletController {
 
     @ResourceMapping
     public void proxyResourceTarget(final @RequestParam("proxy.url") String url, final ResourceRequest request, final ResourceResponse response) {
-
-        // locate the content service to use to retrieve our HTML content
-        final IContentService<IContentRequest,IContentResponse> contentService = selectContentService(request);
-
-        // construct the proxy request
-        final IContentRequest proxyRequest;
-        try {
-            proxyRequest = contentService.getRequest(request);
-        } catch (RuntimeException e) {
-            log.error("URL {} was not in the proxy list", url);
-            response.setProperty(ResourceResponse.HTTP_STATUS_CODE, String.valueOf(HttpServletResponse.SC_UNAUTHORIZED));
-            return;
-        }
-
-        // retrieve the HTML content
-        final IContentResponse proxyResponse = contentService.getContent(proxyRequest, request);
+        IContentResponse proxyResponse = null;
         OutputStream out = null;
 
         try {
+            proxyResponse = invokeProxy(request);
 
             // TODO: find a cleaner way to handle this.  we probably can't ever
             // have anything except an HTTP response
@@ -255,12 +246,9 @@ public class ProxyPortletController {
     public void searchRequest(EventRequest request, EventResponse response) {
         log.debug("EVENT HANDLER -- START");
 
-        // locate the content service to use to retrieve our HTML content
-        final IContentService<IContentRequest,IContentResponse> contentService = selectContentService(request);
-
         try {
             // retrieve the HTML content
-            final IContentResponse proxyResponse = invokeProxy(contentService, request);
+            final IContentResponse proxyResponse = invokeProxy(request);
             final Document document = parseDocument(request, proxyResponse);
             SearchResults searchResults = searchService.search(request, document);
             response.setEvent(SearchConstants.SEARCH_RESULTS_QNAME, searchResults);
@@ -278,15 +266,18 @@ public class ProxyPortletController {
     /**
      * @throws NoSuchBeanDefinitionException If there is no such bean
      */
-    private IContentService<IContentRequest,IContentResponse> selectContentService(final PortletRequest req) {
+    private IContentService<IContentRequest, IContentResponse> selectContentService(final PortletRequest req) {
         final PortletPreferences prefs = req.getPreferences();
         final String contentServiceKey = prefs.getValue(CONTENT_SERVICE_KEY, null);
-        @SuppressWarnings("unchecked")
-        final IContentService<IContentRequest,IContentResponse> rslt = applicationContext.getBean(contentServiceKey, IContentService.class);
+        @SuppressWarnings("unchecked") final IContentService<IContentRequest, IContentResponse> rslt = applicationContext.getBean(contentServiceKey, IContentService.class);
         return rslt;
     }
 
-    private IContentResponse invokeProxy(final IContentService<IContentRequest,IContentResponse> contentService, final PortletRequest req) {
+    private IContentResponse invokeProxy(final PortletRequest req) {
+
+        // locate the content service to use to retrieve our HTML content
+        final IContentService<IContentRequest, IContentResponse> contentService = selectContentService(req);
+
         final IContentRequest proxyRequest;
         try {
             proxyRequest = contentService.getRequest(req);

--- a/src/main/java/org/jasig/portlet/proxy/service/proxy/document/URLRewritingFilter.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/proxy/document/URLRewritingFilter.java
@@ -122,7 +122,7 @@ public class URLRewritingFilter implements IDocumentFilter {
         final PortletPreferences preferences = request.getPreferences();
         final String[] whitelistRegexes = preferences.getValues("whitelistRegexes", new String[] {});
 
-        // If we're proxying a remote website (as opposed to a local file system 
+        // If we're proxying a remote website (as opposed to a local file system
         // resources, we'll need to transform any relative URLs.  To do this,
         // we first compute the base and relative URLs for the page.
         String baseUrl = null;
@@ -162,7 +162,7 @@ public class URLRewritingFilter implements IDocumentFilter {
                         continue;
                     }
 
-                    // if we're proxying a remote website, adjust any 
+                    // if we're proxying a remote website, adjust any
                     // relative URLs into absolute URLs
                     if (baseUrl != null) {
 
@@ -184,7 +184,7 @@ public class URLRewritingFilter implements IDocumentFilter {
 
                     }
 
-                    // if this URL matches our whitelist regex, rewrite it 
+                    // if this URL matches our whitelist regex, rewrite it
                     // to pass through this portlet
                     for (String regex : whitelistRegexes) {
 
@@ -203,13 +203,9 @@ public class URLRewritingFilter implements IDocumentFilter {
                                       element.attr("method", "POST");
                                   }
                                   attributeUrl = createFormUrl(response, isPost, attributeUrl);
-                              }
-
-                              else if (action) {
+                              } else if (action) {
                                   attributeUrl = createActionUrl(response, attributeUrl);
-                              }
-
-                              else {
+                              } else {
                                   attributeUrl = createResourceUrl(response, attributeUrl);
                               }
                           }
@@ -235,7 +231,7 @@ public class URLRewritingFilter implements IDocumentFilter {
     }
 
     protected String createActionUrl(final RenderResponse response, final String url) {
-        final PortletURL portletUrl = response.createActionURL();
+        final PortletURL portletUrl = response.createRenderURL();
         portletUrl.setParameter(HttpContentServiceImpl.URL_PARAM, url);
         return portletUrl.toString();
     }


### PR DESCRIPTION
Due to changes in uPortal for security reasons, action links can only be processed as POSTs. The Web Proxy URL rewrite code was creating action URLs with <a> tags. Since these links are just passing through, it makes sense to make them render URLs with <a> tags rather than change change <a> tags into <form> blocks with action URLs.

This PR changes a lot of code in 2 files. Please review carefully.