### PR TITLE
fix: update maven javadoc plugin with new doclint tag

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,4 +26,4 @@ jobs:
           distribution: adopt-hotspot
           java-version: 8
       - name: Build and Test
-        run: 'mvn -B -Dmaven.javadoc.skip=true package'
+        run: 'mvn -B package'

--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
                           <artifactId>maven-javadoc-plugin</artifactId>
                           <version>3.2.0</version>
                           <configuration>
-                              <additionalparam>-Xdoclint:none</additionalparam>
+                              <doclint>none</doclint>
                           </configuration>
                       </plugin>
                   </plugins>


### PR DESCRIPTION
Updated version of Maven Javadoc plugin change how to configure doclint.