### PR TITLE
chore: remove "provided" dep on log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,12 +204,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4jVersion}</version>


### PR DESCRIPTION
"Provided" dependencies are a way to note that the dep is going to be included by the container. Since we are not deploying it yet it's flagged as a security issue, I am simply removing it. No issues since the portlet has already been switched to Slf4j.