### PR TITLE
fix: replace tokens in URL b/c curly braces are illegal

### DIFF
--- a/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/UserInfoUrlParameterizingPreInterceptor.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/UserInfoUrlParameterizingPreInterceptor.java
@@ -85,6 +85,9 @@ public class UserInfoUrlParameterizingPreInterceptor implements IPreInterceptor 
 				}
 			}
 
+			// curly braces are illegal URL characters
+			url = removeRemainingUrlTokens(url);
+
 			// update the URL in the content request
 			proxyRequest.setProxiedLocation(url);
 
@@ -92,6 +95,11 @@ public class UserInfoUrlParameterizingPreInterceptor implements IPreInterceptor 
 			log.error("Exception while encoding URL parameters", e);
 		}
 
+	}
+
+	private String removeRemainingUrlTokens(String url) {
+	  String s = url.replaceAll("/\\{[^\\}]*\\}/", "/");
+	  return s.replaceAll("\\{[^\\}]*\\}", "");
 	}
 
 	@Override

--- a/src/test/java/org/jasig/portlet/proxy/service/web/interceptor/UserInfoUrlParameterizingPreInterceptorTest.java
+++ b/src/test/java/org/jasig/portlet/proxy/service/web/interceptor/UserInfoUrlParameterizingPreInterceptorTest.java
@@ -57,7 +57,6 @@ public class UserInfoUrlParameterizingPreInterceptorTest {
 		proxyRequest = new HttpContentRequestImpl();
 		proxyRequest.setParameters(parameters);
 		proxyRequest.setProxiedLocation("http://somewhere.com/rest/test/id");
-		
 	}
 
 	@Test
@@ -74,19 +73,52 @@ public class UserInfoUrlParameterizingPreInterceptorTest {
 	public void testReplacePathElement() {
 		proxyRequest.setProxiedLocation("http://somewhere.com/rest/{test}/id");
 		preprocessor.intercept(proxyRequest, portletRequest);
-		
-		assertEquals("http://somewhere.com/rest/somevalue/id", proxyRequest.getProxiedLocation());
 
+		assertEquals("http://somewhere.com/rest/somevalue/id", proxyRequest.getProxiedLocation());
 	}
-	
+
 	@Test
-	public void testReplaceParamter() {
+	public void testNonReplacePathElement() {
+		proxyRequest.setProxiedLocation("http://somewhere.com/rest/{unknown_attr}/id");
+		preprocessor.intercept(proxyRequest, portletRequest);
+		
+		assertEquals("http://somewhere.com/rest/id", proxyRequest.getProxiedLocation());
+	}
+
+	@Test
+	public void testReplaceParam() {
+		proxyRequest.setProxiedLocation("http://somewhere.com/rest/id?param={test}");
+		preprocessor.intercept(proxyRequest, portletRequest);
+
+		assertEquals("http://somewhere.com/rest/id?param=somevalue", proxyRequest.getProxiedLocation());
+	}
+
+	@Test
+	public void testNonReplaceParam() {
+		proxyRequest.setProxiedLocation("http://somewhere.com/rest/id?param={missing_attr}");
+		preprocessor.intercept(proxyRequest, portletRequest);
+
+		assertEquals("http://somewhere.com/rest/id?param=", proxyRequest.getProxiedLocation());
+	}
+
+	@Test
+	public void testReplaceParameter() {
 		IFormField formField = new FormFieldImpl("param", new String[]{"val1", "{test}"});
+		parameters.put("param", formField);
+		preprocessor.intercept(proxyRequest, portletRequest);
+
+		assertEquals("val1", proxyRequest.getParameters().get("param").getValues()[0]);
+		assertEquals("somevalue", proxyRequest.getParameters().get("param").getValues()[1]);
+	}
+
+	@Test
+	public void testNonReplaceParameter() {
+		IFormField formField = new FormFieldImpl("param", new String[]{"val1", "{missing_attr}"});
 		parameters.put("param", formField);
 		preprocessor.intercept(proxyRequest, portletRequest);
 		
 		assertEquals("val1", proxyRequest.getParameters().get("param").getValues()[0]);
-		assertEquals("somevalue", proxyRequest.getParameters().get("param").getValues()[1]);
+		assertEquals("{missing_attr}", proxyRequest.getParameters().get("param").getValues()[1]);
 	}
 
 }


### PR DESCRIPTION
Tokens missing user attribute matches were left in the URL. This leaves curly braces in the URL which are illegal characters. This PR removes tokens from the URL (added unit tests) but leaves tokens in forms alone. This is asymmetrical; however a form field may have valid need for these characters. 